### PR TITLE
Modernise codebase: Pipfile, Python 3.10+, PEP 8, real tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,14 @@
 language: python
 python:
-  - "3.6"
-  - "3.7"
-  - "3.8"
-  - "3.9"
+  - "3.10"
+  - "3.11"
+  - "3.12"
+  - "3.13"
 
-# command to install dependencies
-install:
-  - pip install -r requirements.txt
-  - pip install -r requirements-test.txt
-
-# install nfcu
 before_install:
-  - pip install -e .
+  - pip install pipenv
+  - pipenv install --dev
+  - pipenv run pip install -e .
 
 stages:
   - lint
@@ -22,13 +18,12 @@ jobs:
   include:
     - stage: lint
       name: "pylint"
-      script: pylint nfcu/
+      script: pipenv run pylint nfcu/
     - name: "pycodestyle"
-      script: pycodestyle nfcu/
+      script: pipenv run pycodestyle nfcu/
     - stage: test
       name: "pytest"
-      script: pytest test/
+      script: pipenv run pytest test/
 
-# code coverage
 after_success:
-  - coveralls
+  - pipenv run coveralls

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,17 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+requests = ">=2.32.0"
+
+[dev-packages]
+coverage = ">=7.0"
+coveralls = ">=3.3"
+pycodestyle = ">=2.11"
+pylint = ">=3.0"
+pytest = ">=8.0"
+
+[requires]
+python_version = "3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,633 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "a1f216652efbacfe479cd1cf2b2f3adb61b4f7ff5035a5a0247d3d3d7f77462c"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.10"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa",
+                "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2026.2.25"
+        },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:027f6de494925c0ab2a55eab46ae5129951638a49a34d87f4c3eda90f696b4ad",
+                "sha256:077fbb858e903c73f6c9db43374fd213b0b6a778106bc7032446a8e8b5b38b93",
+                "sha256:0a98e6759f854bd25a58a73fa88833fba3b7c491169f86ce1180c948ab3fd394",
+                "sha256:0d3d8f15c07f86e9ff82319b3d9ef6f4bf907608f53fe9d92b28ea9ae3d1fd89",
+                "sha256:0f04b14ffe5fdc8c4933862d8306109a2c51e0704acfa35d51598eb45a1e89fc",
+                "sha256:11d694519d7f29d6cd09f6ac70028dba10f92f6cdd059096db198c283794ac86",
+                "sha256:194f08cbb32dc406d6e1aea671a68be0823673db2832b38405deba2fb0d88f63",
+                "sha256:1bee1e43c28aa63cb16e5c14e582580546b08e535299b8b6158a7c9c768a1f3d",
+                "sha256:21d142cc6c0ec30d2efee5068ca36c128a30b0f2c53c1c07bd78cb6bc1d3be5f",
+                "sha256:2437418e20515acec67d86e12bf70056a33abdacb5cb1655042f6538d6b085a8",
+                "sha256:244bfb999c71b35de57821b8ea746b24e863398194a4014e4c76adc2bbdfeff0",
+                "sha256:2677acec1a2f8ef614c6888b5b4ae4060cc184174a938ed4e8ef690e15d3e505",
+                "sha256:277e970e750505ed74c832b4bf75dac7476262ee2a013f5574dd49075879e161",
+                "sha256:2aaba3b0819274cc41757a1da876f810a3e4d7b6eb25699253a4effef9e8e4af",
+                "sha256:2b7d8f6c26245217bd2ad053761201e9f9680f8ce52f0fcd8d0755aeae5b2152",
+                "sha256:2c9d3c380143a1fedbff95a312aa798578371eb29da42106a29019368a475318",
+                "sha256:3162d5d8ce1bb98dd51af660f2121c55d0fa541b46dff7bb9b9f86ea1d87de72",
+                "sha256:31fd66405eaf47bb62e8cd575dc621c56c668f27d46a61d975a249930dd5e2a4",
+                "sha256:362d61fd13843997c1c446760ef36f240cf81d3ebf74ac62652aebaf7838561e",
+                "sha256:376bec83a63b8021bb5c8ea75e21c4ccb86e7e45ca4eb81146091b56599b80c3",
+                "sha256:44c2a8734b333e0578090c4cd6b16f275e07aa6614ca8715e6c038e865e70576",
+                "sha256:47cc91b2f4dd2833fddaedd2893006b0106129d4b94fdb6af1f4ce5a9965577c",
+                "sha256:4902828217069c3c5c71094537a8e623f5d097858ac6ca8252f7b4d10b7560f1",
+                "sha256:4bd5d4137d500351a30687c2d3971758aac9a19208fc110ccb9d7188fbe709e8",
+                "sha256:4fe7859a4e3e8457458e2ff592f15ccb02f3da787fcd31e0183879c3ad4692a1",
+                "sha256:542d2cee80be6f80247095cc36c418f7bddd14f4a6de45af91dfad36d817bba2",
+                "sha256:554af85e960429cf30784dd47447d5125aaa3b99a6f0683589dbd27e2f45da44",
+                "sha256:5833d2c39d8896e4e19b689ffc198f08ea58116bee26dea51e362ecc7cd3ed26",
+                "sha256:5947809c8a2417be3267efc979c47d76a079758166f7d43ef5ae8e9f92751f88",
+                "sha256:5ae497466c7901d54b639cf42d5b8c1b6a4fead55215500d2f486d34db48d016",
+                "sha256:5bd2293095d766545ec1a8f612559f6b40abc0eb18bb2f5d1171872d34036ede",
+                "sha256:5bfbb1b9acf3334612667b61bd3002196fe2a1eb4dd74d247e0f2a4d50ec9bbf",
+                "sha256:5cb4d72eea50c8868f5288b7f7f33ed276118325c1dfd3957089f6b519e1382a",
+                "sha256:5dbe56a36425d26d6cfb40ce79c314a2e4dd6211d51d6d2191c00bed34f354cc",
+                "sha256:5f819d5fe9234f9f82d75bdfa9aef3a3d72c4d24a6e57aeaebba32a704553aa0",
+                "sha256:64b55f9dce520635f018f907ff1b0df1fdc31f2795a922fb49dd14fbcdf48c84",
+                "sha256:6515f3182dbe4ea06ced2d9e8666d97b46ef4c75e326b79bb624110f122551db",
+                "sha256:65e2befcd84bc6f37095f5961e68a6f077bf44946771354a28ad434c2cce0ae1",
+                "sha256:6aee717dcfead04c6eb1ce3bd29ac1e22663cdea57f943c87d1eab9a025438d7",
+                "sha256:6b39f987ae8ccdf0d2642338faf2abb1862340facc796048b604ef14919e55ed",
+                "sha256:6e1fcf0720908f200cd21aa4e6750a48ff6ce4afe7ff5a79a90d5ed8a08296f8",
+                "sha256:74018750915ee7ad843a774364e13a3db91682f26142baddf775342c3f5b1133",
+                "sha256:74664978bb272435107de04e36db5a9735e78232b85b77d45cfb38f758efd33e",
+                "sha256:74bb723680f9f7a6234dcf67aea57e708ec1fbdf5699fb91dfd6f511b0a320ef",
+                "sha256:752944c7ffbfdd10c074dc58ec2d5a8a4cd9493b314d367c14d24c17684ddd14",
+                "sha256:778d2e08eda00f4256d7f672ca9fef386071c9202f5e4607920b86d7803387f2",
+                "sha256:780236ac706e66881f3b7f2f32dfe90507a09e67d1d454c762cf642e6e1586e0",
+                "sha256:798d75d81754988d2565bff1b97ba5a44411867c0cf32b77a7e8f8d84796b10d",
+                "sha256:799a7a5e4fb2d5898c60b640fd4981d6a25f1c11790935a44ce38c54e985f828",
+                "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f",
+                "sha256:7c308f7e26e4363d79df40ca5b2be1c6ba9f02bdbccfed5abddb7859a6ce72cf",
+                "sha256:7fa17817dc5625de8a027cb8b26d9fefa3ea28c8253929b8d6649e705d2835b6",
+                "sha256:81d5eb2a312700f4ecaa977a8235b634ce853200e828fbadf3a9c50bab278328",
+                "sha256:82004af6c302b5d3ab2cfc4cc5f29db16123b1a8417f2e25f9066f91d4411090",
+                "sha256:837c2ce8c5a65a2035be9b3569c684358dfbf109fd3b6969630a87535495ceaa",
+                "sha256:840c25fb618a231545cbab0564a799f101b63b9901f2569faecd6b222ac72381",
+                "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c",
+                "sha256:8af65f14dc14a79b924524b1e7fffe304517b2bff5a58bf64f30b98bbc5079eb",
+                "sha256:8ef3c867360f88ac904fd3f5e1f902f13307af9052646963ee08ff4f131adafc",
+                "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a",
+                "sha256:99ae2cffebb06e6c22bdc25801d7b30f503cc87dbd283479e7b606f70aff57ec",
+                "sha256:9a26f18905b8dd5d685d6d07b0cdf98a79f3c7a918906af7cc143ea2e164c8bc",
+                "sha256:9b35f4c90079ff2e2edc5b26c0c77925e5d2d255c42c74fdb70fb49b172726ac",
+                "sha256:9cd98cdc06614a2f768d2b7286d66805f94c48cde050acdbbb7db2600ab3197e",
+                "sha256:9d1bb833febdff5c8927f922386db610b49db6e0d4f4ee29601d71e7c2694313",
+                "sha256:9f7fcd74d410a36883701fafa2482a6af2ff5ba96b9a620e9e0721e28ead5569",
+                "sha256:a59cb51917aa591b1c4e6a43c132f0cdc3c76dbad6155df4e28ee626cc77a0a3",
+                "sha256:a61900df84c667873b292c3de315a786dd8dac506704dea57bc957bd31e22c7d",
+                "sha256:a79cfe37875f822425b89a82333404539ae63dbdddf97f84dcbc3d339aae9525",
+                "sha256:a8a8b89589086a25749f471e6a900d3f662d1d3b6e2e59dcecf787b1cc3a1894",
+                "sha256:a8bf8d0f749c5757af2142fe7903a9df1d2e8aa3841559b2bad34b08d0e2bcf3",
+                "sha256:a9768c477b9d7bd54bc0c86dbaebdec6f03306675526c9927c0e8a04e8f94af9",
+                "sha256:ac1c4a689edcc530fc9d9aa11f5774b9e2f33f9a0c6a57864e90908f5208d30a",
+                "sha256:af2d8c67d8e573d6de5bc30cdb27e9b95e49115cd9baad5ddbd1a6207aaa82a9",
+                "sha256:b435cba5f4f750aa6c0a0d92c541fb79f69a387c91e61f1795227e4ed9cece14",
+                "sha256:b5b290ccc2a263e8d185130284f8501e3e36c5e02750fc6b6bdeb2e9e96f1e25",
+                "sha256:b5d84d37db046c5ca74ee7bb47dd6cbc13f80665fdde3e8040bdd3fb015ecb50",
+                "sha256:b7cf1017d601aa35e6bb650b6ad28652c9cd78ee6caff19f3c28d03e1c80acbf",
+                "sha256:bc7637e2f80d8530ee4a78e878bce464f70087ce73cf7c1caf142416923b98f1",
+                "sha256:c0463276121fdee9c49b98908b3a89c39be45d86d1dbaa22957e38f6321d4ce3",
+                "sha256:c4ef880e27901b6cc782f1b95f82da9313c0eb95c3af699103088fa0ac3ce9ac",
+                "sha256:c8ae8a0f02f57a6e61203a31428fa1d677cbe50c93622b4149d5c0f319c1d19e",
+                "sha256:ca5862d5b3928c4940729dacc329aa9102900382fea192fc5e52eb69d6093815",
+                "sha256:cb01158d8b88ee68f15949894ccc6712278243d95f344770fa7593fa2d94410c",
+                "sha256:cb6254dc36b47a990e59e1068afacdcd02958bdcce30bb50cc1700a8b9d624a6",
+                "sha256:cc00f04ed596e9dc0da42ed17ac5e596c6ccba999ba6bd92b0e0aef2f170f2d6",
+                "sha256:cd09d08005f958f370f539f186d10aec3377d55b9eeb0d796025d4886119d76e",
+                "sha256:cd4b7ca9984e5e7985c12bc60a6f173f3c958eae74f3ef6624bb6b26e2abbae4",
+                "sha256:ce8a0633f41a967713a59c4139d29110c07e826d131a316b50ce11b1d79b4f84",
+                "sha256:cead0978fc57397645f12578bfd2d5ea9138ea0fac82b2f63f7f7c6877986a69",
+                "sha256:d055ec1e26e441f6187acf818b73564e6e6282709e9bcb5b63f5b23068356a15",
+                "sha256:d1f13550535ad8cff21b8d757a3257963e951d96e20ec82ab44bc64aeb62a191",
+                "sha256:d9c7f57c3d666a53421049053eaacdd14bbd0a528e2186fcb2e672effd053bb0",
+                "sha256:d9e45d7faa48ee908174d8fe84854479ef838fc6a705c9315372eacbc2f02897",
+                "sha256:da3326d9e65ef63a817ecbcc0df6e94463713b754fe293eaa03da99befb9a5bd",
+                "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2",
+                "sha256:e1f185f86a6f3403aa2420e815904c67b2f9ebc443f045edd0de921108345794",
+                "sha256:e824f1492727fa856dd6eda4f7cee25f8518a12f3c4a56a74e8095695089cf6d",
+                "sha256:e912091979546adf63357d7e2ccff9b44f026c075aeaf25a52d0e95ad2281074",
+                "sha256:eaabd426fe94daf8fd157c32e571c85cb12e66692f15516a83a03264b08d06c3",
+                "sha256:ebf3e58c7ec8a8bed6d66a75d7fb37b55e5015b03ceae72a8e7c74495551e224",
+                "sha256:ecaae4149d99b1c9e7b88bb03e3221956f68fd6d50be2ef061b2381b61d20838",
+                "sha256:eecbc200c7fd5ddb9a7f16c7decb07b566c29fa2161a16cf67b8d068bd21690a",
+                "sha256:f155a433c2ec037d4e8df17d18922c3a0d9b3232a396690f17175d2946f0218d",
+                "sha256:f1e34719c6ed0b92f418c7c780480b26b5d9c50349e9a9af7d76bf757530350d",
+                "sha256:f34be2938726fc13801220747472850852fe6b1ea75869a048d6f896838c896f",
+                "sha256:f820802628d2694cb7e56db99213f930856014862f3fd943d290ea8438d07ca8",
+                "sha256:f8bf04158c6b607d747e93949aa60618b61312fe647a6369f88ce2ff16043490",
+                "sha256:f8e160feb2aed042cd657a72acc0b481212ed28b1b9a95c0cee1621b524e1966",
+                "sha256:f9d332f8c2a2fcbffe1378594431458ddbef721c1769d78e2cbc06280d8155f9",
+                "sha256:fa09f53c465e532f4d3db095e0c55b615f010ad81803d383195b6b5ca6cbf5f3",
+                "sha256:faa3a41b2b66b6e50f84ae4a68c64fcd0c44355741c6374813a800cd6695db9e",
+                "sha256:fd44c878ea55ba351104cb93cc85e74916eb8fa440ca7903e57575e97394f608"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.4.4"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea",
+                "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==3.11"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6",
+                "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==2.32.5"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
+                "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==2.6.3"
+        }
+    },
+    "develop": {
+        "astroid": {
+            "hashes": [
+                "sha256:52f39653876c7dec3e3afd4c2696920e05c83832b9737afc21928f2d2eb7a753",
+                "sha256:986fed8bcf79fb82c78b18a53352a0b287a73817d6dbcfba3162da36667c49a0"
+            ],
+            "markers": "python_full_version >= '3.10.0'",
+            "version": "==4.0.4"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa",
+                "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2026.2.25"
+        },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:027f6de494925c0ab2a55eab46ae5129951638a49a34d87f4c3eda90f696b4ad",
+                "sha256:077fbb858e903c73f6c9db43374fd213b0b6a778106bc7032446a8e8b5b38b93",
+                "sha256:0a98e6759f854bd25a58a73fa88833fba3b7c491169f86ce1180c948ab3fd394",
+                "sha256:0d3d8f15c07f86e9ff82319b3d9ef6f4bf907608f53fe9d92b28ea9ae3d1fd89",
+                "sha256:0f04b14ffe5fdc8c4933862d8306109a2c51e0704acfa35d51598eb45a1e89fc",
+                "sha256:11d694519d7f29d6cd09f6ac70028dba10f92f6cdd059096db198c283794ac86",
+                "sha256:194f08cbb32dc406d6e1aea671a68be0823673db2832b38405deba2fb0d88f63",
+                "sha256:1bee1e43c28aa63cb16e5c14e582580546b08e535299b8b6158a7c9c768a1f3d",
+                "sha256:21d142cc6c0ec30d2efee5068ca36c128a30b0f2c53c1c07bd78cb6bc1d3be5f",
+                "sha256:2437418e20515acec67d86e12bf70056a33abdacb5cb1655042f6538d6b085a8",
+                "sha256:244bfb999c71b35de57821b8ea746b24e863398194a4014e4c76adc2bbdfeff0",
+                "sha256:2677acec1a2f8ef614c6888b5b4ae4060cc184174a938ed4e8ef690e15d3e505",
+                "sha256:277e970e750505ed74c832b4bf75dac7476262ee2a013f5574dd49075879e161",
+                "sha256:2aaba3b0819274cc41757a1da876f810a3e4d7b6eb25699253a4effef9e8e4af",
+                "sha256:2b7d8f6c26245217bd2ad053761201e9f9680f8ce52f0fcd8d0755aeae5b2152",
+                "sha256:2c9d3c380143a1fedbff95a312aa798578371eb29da42106a29019368a475318",
+                "sha256:3162d5d8ce1bb98dd51af660f2121c55d0fa541b46dff7bb9b9f86ea1d87de72",
+                "sha256:31fd66405eaf47bb62e8cd575dc621c56c668f27d46a61d975a249930dd5e2a4",
+                "sha256:362d61fd13843997c1c446760ef36f240cf81d3ebf74ac62652aebaf7838561e",
+                "sha256:376bec83a63b8021bb5c8ea75e21c4ccb86e7e45ca4eb81146091b56599b80c3",
+                "sha256:44c2a8734b333e0578090c4cd6b16f275e07aa6614ca8715e6c038e865e70576",
+                "sha256:47cc91b2f4dd2833fddaedd2893006b0106129d4b94fdb6af1f4ce5a9965577c",
+                "sha256:4902828217069c3c5c71094537a8e623f5d097858ac6ca8252f7b4d10b7560f1",
+                "sha256:4bd5d4137d500351a30687c2d3971758aac9a19208fc110ccb9d7188fbe709e8",
+                "sha256:4fe7859a4e3e8457458e2ff592f15ccb02f3da787fcd31e0183879c3ad4692a1",
+                "sha256:542d2cee80be6f80247095cc36c418f7bddd14f4a6de45af91dfad36d817bba2",
+                "sha256:554af85e960429cf30784dd47447d5125aaa3b99a6f0683589dbd27e2f45da44",
+                "sha256:5833d2c39d8896e4e19b689ffc198f08ea58116bee26dea51e362ecc7cd3ed26",
+                "sha256:5947809c8a2417be3267efc979c47d76a079758166f7d43ef5ae8e9f92751f88",
+                "sha256:5ae497466c7901d54b639cf42d5b8c1b6a4fead55215500d2f486d34db48d016",
+                "sha256:5bd2293095d766545ec1a8f612559f6b40abc0eb18bb2f5d1171872d34036ede",
+                "sha256:5bfbb1b9acf3334612667b61bd3002196fe2a1eb4dd74d247e0f2a4d50ec9bbf",
+                "sha256:5cb4d72eea50c8868f5288b7f7f33ed276118325c1dfd3957089f6b519e1382a",
+                "sha256:5dbe56a36425d26d6cfb40ce79c314a2e4dd6211d51d6d2191c00bed34f354cc",
+                "sha256:5f819d5fe9234f9f82d75bdfa9aef3a3d72c4d24a6e57aeaebba32a704553aa0",
+                "sha256:64b55f9dce520635f018f907ff1b0df1fdc31f2795a922fb49dd14fbcdf48c84",
+                "sha256:6515f3182dbe4ea06ced2d9e8666d97b46ef4c75e326b79bb624110f122551db",
+                "sha256:65e2befcd84bc6f37095f5961e68a6f077bf44946771354a28ad434c2cce0ae1",
+                "sha256:6aee717dcfead04c6eb1ce3bd29ac1e22663cdea57f943c87d1eab9a025438d7",
+                "sha256:6b39f987ae8ccdf0d2642338faf2abb1862340facc796048b604ef14919e55ed",
+                "sha256:6e1fcf0720908f200cd21aa4e6750a48ff6ce4afe7ff5a79a90d5ed8a08296f8",
+                "sha256:74018750915ee7ad843a774364e13a3db91682f26142baddf775342c3f5b1133",
+                "sha256:74664978bb272435107de04e36db5a9735e78232b85b77d45cfb38f758efd33e",
+                "sha256:74bb723680f9f7a6234dcf67aea57e708ec1fbdf5699fb91dfd6f511b0a320ef",
+                "sha256:752944c7ffbfdd10c074dc58ec2d5a8a4cd9493b314d367c14d24c17684ddd14",
+                "sha256:778d2e08eda00f4256d7f672ca9fef386071c9202f5e4607920b86d7803387f2",
+                "sha256:780236ac706e66881f3b7f2f32dfe90507a09e67d1d454c762cf642e6e1586e0",
+                "sha256:798d75d81754988d2565bff1b97ba5a44411867c0cf32b77a7e8f8d84796b10d",
+                "sha256:799a7a5e4fb2d5898c60b640fd4981d6a25f1c11790935a44ce38c54e985f828",
+                "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f",
+                "sha256:7c308f7e26e4363d79df40ca5b2be1c6ba9f02bdbccfed5abddb7859a6ce72cf",
+                "sha256:7fa17817dc5625de8a027cb8b26d9fefa3ea28c8253929b8d6649e705d2835b6",
+                "sha256:81d5eb2a312700f4ecaa977a8235b634ce853200e828fbadf3a9c50bab278328",
+                "sha256:82004af6c302b5d3ab2cfc4cc5f29db16123b1a8417f2e25f9066f91d4411090",
+                "sha256:837c2ce8c5a65a2035be9b3569c684358dfbf109fd3b6969630a87535495ceaa",
+                "sha256:840c25fb618a231545cbab0564a799f101b63b9901f2569faecd6b222ac72381",
+                "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c",
+                "sha256:8af65f14dc14a79b924524b1e7fffe304517b2bff5a58bf64f30b98bbc5079eb",
+                "sha256:8ef3c867360f88ac904fd3f5e1f902f13307af9052646963ee08ff4f131adafc",
+                "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a",
+                "sha256:99ae2cffebb06e6c22bdc25801d7b30f503cc87dbd283479e7b606f70aff57ec",
+                "sha256:9a26f18905b8dd5d685d6d07b0cdf98a79f3c7a918906af7cc143ea2e164c8bc",
+                "sha256:9b35f4c90079ff2e2edc5b26c0c77925e5d2d255c42c74fdb70fb49b172726ac",
+                "sha256:9cd98cdc06614a2f768d2b7286d66805f94c48cde050acdbbb7db2600ab3197e",
+                "sha256:9d1bb833febdff5c8927f922386db610b49db6e0d4f4ee29601d71e7c2694313",
+                "sha256:9f7fcd74d410a36883701fafa2482a6af2ff5ba96b9a620e9e0721e28ead5569",
+                "sha256:a59cb51917aa591b1c4e6a43c132f0cdc3c76dbad6155df4e28ee626cc77a0a3",
+                "sha256:a61900df84c667873b292c3de315a786dd8dac506704dea57bc957bd31e22c7d",
+                "sha256:a79cfe37875f822425b89a82333404539ae63dbdddf97f84dcbc3d339aae9525",
+                "sha256:a8a8b89589086a25749f471e6a900d3f662d1d3b6e2e59dcecf787b1cc3a1894",
+                "sha256:a8bf8d0f749c5757af2142fe7903a9df1d2e8aa3841559b2bad34b08d0e2bcf3",
+                "sha256:a9768c477b9d7bd54bc0c86dbaebdec6f03306675526c9927c0e8a04e8f94af9",
+                "sha256:ac1c4a689edcc530fc9d9aa11f5774b9e2f33f9a0c6a57864e90908f5208d30a",
+                "sha256:af2d8c67d8e573d6de5bc30cdb27e9b95e49115cd9baad5ddbd1a6207aaa82a9",
+                "sha256:b435cba5f4f750aa6c0a0d92c541fb79f69a387c91e61f1795227e4ed9cece14",
+                "sha256:b5b290ccc2a263e8d185130284f8501e3e36c5e02750fc6b6bdeb2e9e96f1e25",
+                "sha256:b5d84d37db046c5ca74ee7bb47dd6cbc13f80665fdde3e8040bdd3fb015ecb50",
+                "sha256:b7cf1017d601aa35e6bb650b6ad28652c9cd78ee6caff19f3c28d03e1c80acbf",
+                "sha256:bc7637e2f80d8530ee4a78e878bce464f70087ce73cf7c1caf142416923b98f1",
+                "sha256:c0463276121fdee9c49b98908b3a89c39be45d86d1dbaa22957e38f6321d4ce3",
+                "sha256:c4ef880e27901b6cc782f1b95f82da9313c0eb95c3af699103088fa0ac3ce9ac",
+                "sha256:c8ae8a0f02f57a6e61203a31428fa1d677cbe50c93622b4149d5c0f319c1d19e",
+                "sha256:ca5862d5b3928c4940729dacc329aa9102900382fea192fc5e52eb69d6093815",
+                "sha256:cb01158d8b88ee68f15949894ccc6712278243d95f344770fa7593fa2d94410c",
+                "sha256:cb6254dc36b47a990e59e1068afacdcd02958bdcce30bb50cc1700a8b9d624a6",
+                "sha256:cc00f04ed596e9dc0da42ed17ac5e596c6ccba999ba6bd92b0e0aef2f170f2d6",
+                "sha256:cd09d08005f958f370f539f186d10aec3377d55b9eeb0d796025d4886119d76e",
+                "sha256:cd4b7ca9984e5e7985c12bc60a6f173f3c958eae74f3ef6624bb6b26e2abbae4",
+                "sha256:ce8a0633f41a967713a59c4139d29110c07e826d131a316b50ce11b1d79b4f84",
+                "sha256:cead0978fc57397645f12578bfd2d5ea9138ea0fac82b2f63f7f7c6877986a69",
+                "sha256:d055ec1e26e441f6187acf818b73564e6e6282709e9bcb5b63f5b23068356a15",
+                "sha256:d1f13550535ad8cff21b8d757a3257963e951d96e20ec82ab44bc64aeb62a191",
+                "sha256:d9c7f57c3d666a53421049053eaacdd14bbd0a528e2186fcb2e672effd053bb0",
+                "sha256:d9e45d7faa48ee908174d8fe84854479ef838fc6a705c9315372eacbc2f02897",
+                "sha256:da3326d9e65ef63a817ecbcc0df6e94463713b754fe293eaa03da99befb9a5bd",
+                "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2",
+                "sha256:e1f185f86a6f3403aa2420e815904c67b2f9ebc443f045edd0de921108345794",
+                "sha256:e824f1492727fa856dd6eda4f7cee25f8518a12f3c4a56a74e8095695089cf6d",
+                "sha256:e912091979546adf63357d7e2ccff9b44f026c075aeaf25a52d0e95ad2281074",
+                "sha256:eaabd426fe94daf8fd157c32e571c85cb12e66692f15516a83a03264b08d06c3",
+                "sha256:ebf3e58c7ec8a8bed6d66a75d7fb37b55e5015b03ceae72a8e7c74495551e224",
+                "sha256:ecaae4149d99b1c9e7b88bb03e3221956f68fd6d50be2ef061b2381b61d20838",
+                "sha256:eecbc200c7fd5ddb9a7f16c7decb07b566c29fa2161a16cf67b8d068bd21690a",
+                "sha256:f155a433c2ec037d4e8df17d18922c3a0d9b3232a396690f17175d2946f0218d",
+                "sha256:f1e34719c6ed0b92f418c7c780480b26b5d9c50349e9a9af7d76bf757530350d",
+                "sha256:f34be2938726fc13801220747472850852fe6b1ea75869a048d6f896838c896f",
+                "sha256:f820802628d2694cb7e56db99213f930856014862f3fd943d290ea8438d07ca8",
+                "sha256:f8bf04158c6b607d747e93949aa60618b61312fe647a6369f88ce2ff16043490",
+                "sha256:f8e160feb2aed042cd657a72acc0b481212ed28b1b9a95c0cee1621b524e1966",
+                "sha256:f9d332f8c2a2fcbffe1378594431458ddbef721c1769d78e2cbc06280d8155f9",
+                "sha256:fa09f53c465e532f4d3db095e0c55b615f010ad81803d383195b6b5ca6cbf5f3",
+                "sha256:faa3a41b2b66b6e50f84ae4a68c64fcd0c44355741c6374813a800cd6695db9e",
+                "sha256:fd44c878ea55ba351104cb93cc85e74916eb8fa440ca7903e57575e97394f608"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.4.4"
+        },
+        "coverage": {
+            "extras": [
+                "toml"
+            ],
+            "hashes": [
+                "sha256:01d4cbc3c283a17fc1e42d614a119f7f438eabb593391283adca8dc86eff1246",
+                "sha256:02231499b08dabbe2b96612993e5fc34217cdae907a51b906ac7fca8027a4459",
+                "sha256:0dd7ab8278f0d58a0128ba2fca25824321f05d059c1441800e934ff2efa52129",
+                "sha256:0e086334e8537ddd17e5f16a344777c1ab8194986ec533711cbe6c41cde841b6",
+                "sha256:0fc31c787a84f8cd6027eba44010517020e0d18487064cd3d8968941856d1415",
+                "sha256:14375934243ee05f56c45393fe2ce81fe5cc503c07cee2bdf1725fb8bef3ffaf",
+                "sha256:1731dc33dc276dafc410a885cbf5992f1ff171393e48a21453b78727d090de80",
+                "sha256:19bc3c88078789f8ef36acb014d7241961dbf883fd2533d18cb1e7a5b4e28b11",
+                "sha256:1af1641e57cf7ba1bd67d677c9abdbcd6cc2ab7da3bca7fa1e2b7e50e65f2ad0",
+                "sha256:1d4be36a5114c499f9f1f9195e95ebf979460dbe2d88e6816ea202010ba1c34b",
+                "sha256:200dea7d1e8095cc6e98cdabe3fd1d21ab17d3cee6dab00cadbb2fe35d9c15b9",
+                "sha256:23e3f687cf945070d1c90f85db66d11e3025665d8dafa831301a0e0038f3db9b",
+                "sha256:2421d591f8ca05b308cf0092807308b2facbefe54af7c02ac22548b88b95c98f",
+                "sha256:245e37f664d89861cf2329c9afa2c1fe9e6d4e1a09d872c947e70718aeeac505",
+                "sha256:25381386e80ae727608e662474db537d4df1ecd42379b5ba33c84633a2b36d47",
+                "sha256:25a41c3104d08edb094d9db0d905ca54d0cd41c928bb6be3c4c799a54753af55",
+                "sha256:296f8b0af861d3970c2a4d8c91d48eb4dd4771bcef9baedec6a9b515d7de3def",
+                "sha256:29e3220258d682b6226a9b0925bc563ed9a1ebcff3cad30f043eceea7eaf2689",
+                "sha256:2a09cfa6a5862bc2fc6ca7c3def5b2926194a56b8ab78ffcf617d28911123012",
+                "sha256:2b0f6ccf3dbe577170bebfce1318707d0e8c3650003cb4b3a9dd744575daa8b5",
+                "sha256:2c048ea43875fbf8b45d476ad79f179809c590ec7b79e2035c662e7afa3192e3",
+                "sha256:2cb0f1e000ebc419632bbe04366a8990b6e32c4e0b51543a6484ffe15eaeda95",
+                "sha256:2fa8d5f8de70688a28240de9e139fa16b153cc3cbb01c5f16d88d6505ebdadf9",
+                "sha256:300deaee342f90696ed186e3a00c71b5b3d27bffe9e827677954f4ee56969601",
+                "sha256:30b8d0512f2dc8c8747557e8fb459d6176a2c9e5731e2b74d311c03b78451997",
+                "sha256:33901f604424145c6e9c2398684b92e176c0b12df77d52db81c20abd48c3794c",
+                "sha256:3599eb3992d814d23b35c536c28df1a882caa950f8f507cef23d1cbf334995ac",
+                "sha256:391ee8f19bef69210978363ca930f7328081c6a0152f1166c91f0b5fdd2a773c",
+                "sha256:3998e5a32e62fdf410c0dbd3115df86297995d6e3429af80b8798aad894ca7aa",
+                "sha256:3c06f0f1337c667b971ca2f975523347e63ec5e500b9aa5882d91931cd3ef750",
+                "sha256:40aa8808140e55dc022b15d8aa7f651b6b3d68b365ea0398f1441e0b04d859c3",
+                "sha256:40d74da8e6c4b9ac18b15331c4b5ebc35a17069410cad462ad4f40dcd2d50c0d",
+                "sha256:4223b4230a376138939a9173f1bdd6521994f2aff8047fae100d6d94d50c5a12",
+                "sha256:48685fee12c2eb3b27c62f2658e7ea21e9c3239cba5a8a242801a0a3f6a8c62a",
+                "sha256:4c7d3cc01e7350f2f0f6f7036caaf5673fb56b6998889ccfe9e1c1fe75a9c932",
+                "sha256:4e83efc079eb39480e6346a15a1bcb3e9b04759c5202d157e1dd4303cd619356",
+                "sha256:4fc7fa81bbaf5a02801b65346c8b3e657f1d93763e58c0abdf7c992addd81a92",
+                "sha256:53d133df809c743eb8bce33b24bcababb371f4441340578cd406e084d94a6148",
+                "sha256:590c0ed4bf8e85f745e6b805b2e1c457b2e33d5255dd9729743165253bc9ad39",
+                "sha256:5b856a8ccf749480024ff3bd7310adaef57bf31fd17e1bfc404b7940b6986634",
+                "sha256:65dfcbe305c3dfe658492df2d85259e0d79ead4177f9ae724b6fb245198f55d6",
+                "sha256:6f01afcff62bf9a08fb32b2c1d6e924236c0383c02c790732b6537269e466a72",
+                "sha256:6fdef321fdfbb30a197efa02d48fcd9981f0d8ad2ae8903ac318adc653f5df98",
+                "sha256:71ca20079dd8f27fcf808817e281e90220475cd75115162218d0e27549f95fef",
+                "sha256:725d985c5ab621268b2edb8e50dfe57633dc69bda071abc470fed55a14935fd3",
+                "sha256:75eab1ebe4f2f64d9509b984f9314d4aa788540368218b858dad56dc8f3e5eb9",
+                "sha256:75fcd519f2a5765db3f0e391eb3b7d150cce1a771bf4c9f861aeab86c767a3c0",
+                "sha256:76451d1978b95ba6507a039090ba076105c87cc76fc3efd5d35d72093964d49a",
+                "sha256:784fc3cf8be001197b652d51d3fd259b1e2262888693a4636e18879f613a62a9",
+                "sha256:78cdf0d578b15148b009ccf18c686aa4f719d887e76e6b40c38ffb61d264a552",
+                "sha256:79be69cf7f3bf9b0deeeb062eab7ac7f36cd4cc4c4dd694bd28921ba4d8596cc",
+                "sha256:79e73a76b854d9c6088fe5d8b2ebe745f8681c55f7397c3c0a016192d681045f",
+                "sha256:7b322db1284a2ed3aa28ffd8ebe3db91c929b7a333c0820abec3d838ef5b3525",
+                "sha256:7d41eead3cc673cbd38a4417deb7fd0b4ca26954ff7dc6078e33f6ff97bed940",
+                "sha256:7eda778067ad7ffccd23ecffce537dface96212576a07924cbf0d8799d2ded5a",
+                "sha256:7f57b33491e281e962021de110b451ab8a24182589be17e12a22c79047935e23",
+                "sha256:8041b6c5bfdc03257666e9881d33b1abc88daccaf73f7b6340fb7946655cd10f",
+                "sha256:8248977c2e33aecb2ced42fef99f2d319e9904a36e55a8a68b69207fb7e43edc",
+                "sha256:845f352911777a8e722bfce168958214951e07e47e5d5d9744109fa5fe77f79b",
+                "sha256:85480adfb35ffc32d40918aad81b89c69c9cc5661a9b8a81476d3e645321a056",
+                "sha256:8e264226ec98e01a8e1054314af91ee6cde0eacac4f465cc93b03dbe0bce2fd7",
+                "sha256:8e798c266c378da2bd819b0677df41ab46d78065fb2a399558f3f6cae78b2fbb",
+                "sha256:9181a3ccead280b828fae232df12b16652702b49d41e99d657f46cc7b1f6ec7a",
+                "sha256:9351229c8c8407645840edcc277f4a2d44814d1bc34a2128c11c2a031d45a5dd",
+                "sha256:93550784d9281e374fb5a12bf1324cc8a963fd63b2d2f223503ef0fd4aa339ea",
+                "sha256:9401ebc7ef522f01d01d45532c68c5ac40fb27113019b6b7d8b208f6e9baa126",
+                "sha256:94eb63f9b363180aff17de3e7c8760c3ba94664ea2695c52f10111244d16a299",
+                "sha256:9d107aff57a83222ddbd8d9ee705ede2af2cc926608b57abed8ef96b50b7e8f9",
+                "sha256:a32ebc02a1805adf637fc8dec324b5cdacd2e493515424f70ee33799573d661b",
+                "sha256:a3aa4e7b9e416774b21797365b358a6e827ffadaaca81b69ee02946852449f00",
+                "sha256:a6f94a7d00eb18f1b6d403c91a88fd58cfc92d4b16080dfdb774afc8294469bf",
+                "sha256:aa3feb8db2e87ff5e6d00d7e1480ae241876286691265657b500886c98f38bda",
+                "sha256:ad27098a189e5838900ce4c2a99f2fe42a0bf0c2093c17c69b45a71579e8d4a2",
+                "sha256:ae4578f8528569d3cf303fef2ea569c7f4c4059a38c8667ccef15c6e1f118aa5",
+                "sha256:b1ec7b6b6e93255f952e27ab58fbc68dcc468844b16ecbee881aeb29b6ab4d8d",
+                "sha256:b507778ae8a4c915436ed5c2e05b4a6cecfa70f734e19c22a005152a11c7b6a9",
+                "sha256:b66a2da594b6068b48b2692f043f35d4d3693fb639d5ea8b39533c2ad9ac3ab9",
+                "sha256:b720ce6a88a2755f7c697c23268ddc47a571b88052e6b155224347389fdf6a3b",
+                "sha256:b7b38448866e83176e28086674fe7368ab8590e4610fb662b44e345b86d63ffa",
+                "sha256:b8eb931ee8e6d8243e253e5ed7336deea6904369d2fd8ae6e43f68abbf167092",
+                "sha256:bb28c0f2cf2782508a40cec377935829d5fcc3ad9a3681375af4e84eb34b6b58",
+                "sha256:bd60d4fe2f6fa7dff9223ca1bbc9f05d2b6697bc5961072e5d3b952d46e1b1ea",
+                "sha256:c35eb28c1d085eb7d8c9b3296567a1bebe03ce72962e932431b9a61f28facf26",
+                "sha256:c4240e7eded42d131a2d2c4dec70374b781b043ddc79a9de4d55ca71f8e98aea",
+                "sha256:caa421e2684e382c5d8973ac55e4f36bed6821a9bad5c953494de960c74595c9",
+                "sha256:d490ba50c3f35dd7c17953c68f3270e7ccd1c6642e2d2afe2d8e720b98f5a053",
+                "sha256:d65b2d373032411e86960604dc4edac91fdfb5dca539461cf2cbe78327d1e64f",
+                "sha256:dae88bc0fc77edaa65c14be099bd57ee140cf507e6bfdeea7938457ab387efb0",
+                "sha256:de6defc1c9badbf8b9e67ae90fd00519186d6ab64e5cc5f3d21359c2a9b2c1d3",
+                "sha256:e101609bcbbfb04605ea1027b10dc3735c094d12d40826a60f897b98b1c30256",
+                "sha256:e24f9156097ff9dc286f2f913df3a7f63c0e333dcafa3c196f2c18b4175ca09a",
+                "sha256:e2f25215f1a359ab17320b47bcdaca3e6e6356652e8256f2441e4ef972052903",
+                "sha256:e5c8f6ed1e61a8b2dcdf31eb0b9bbf0130750ca79c1c49eb898e2ad86f5ccc91",
+                "sha256:e6f70dec1cc557e52df5306d051ef56003f74d56e9c4dd7ddb07e07ef32a84dd",
+                "sha256:e856bf6616714c3a9fbc270ab54103f4e685ba236fa98c054e8f87f266c93505",
+                "sha256:e87f6c587c3f34356c3759f0420693e35e7eb0e2e41e4c011cb6ec6ecbbf1db7",
+                "sha256:eb30bf180de3f632cd043322dad5751390e5385108b2807368997d1a92a509d0",
+                "sha256:eb88b316ec33760714a4720feb2816a3a59180fd58c1985012054fa7aebee4c2",
+                "sha256:eb9078108fbf0bcdde37c3f4779303673c2fa1fe8f7956e68d447d0dd426d38a",
+                "sha256:ecae9737b72408d6a950f7e525f30aca12d4bd8dd95e37342e5beb3a2a8c4f71",
+                "sha256:ee756f00726693e5ba94d6df2bdfd64d4852d23b09bb0bc700e3b30e6f333985",
+                "sha256:f4594c67d8a7c89cf922d9df0438c7c7bb022ad506eddb0fdb2863359ff78242",
+                "sha256:f53d492307962561ac7de4cd1de3e363589b000ab69617c6156a16ba7237998d",
+                "sha256:fb07dc5da7e849e2ad31a5d74e9bece81f30ecf5a42909d0a695f8bd1874d6af",
+                "sha256:fb26a934946a6afe0e326aebe0730cdff393a8bc0bbb65a2f41e30feddca399c",
+                "sha256:fdfc1e28e7c7cdce44985b3043bc13bbd9c747520f94a4d7164af8260b3d91f0"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==7.13.4"
+        },
+        "coveralls": {
+            "hashes": [
+                "sha256:3940f613eac6b3c14d1425741929e1d15f57666f5e7ae0572bbe92357bd6f7ee",
+                "sha256:7c21ffa2808d3052fa0cfca3842a9f3d21cc8eada02538c192d932199e5f07d4"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.10' and python_version < '4.0'",
+            "version": "==4.0.2"
+        },
+        "dill": {
+            "hashes": [
+                "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d",
+                "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==0.4.1"
+        },
+        "docopt": {
+            "hashes": [
+                "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
+            ],
+            "version": "==0.6.2"
+        },
+        "exceptiongroup": {
+            "hashes": [
+                "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219",
+                "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.3.1"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea",
+                "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==3.11"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730",
+                "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==2.3.0"
+        },
+        "isort": {
+            "hashes": [
+                "sha256:184916a933041c7cf718787f7e52064f3c06272aff69a5cb4dc46497bd8911d9",
+                "sha256:fddea59202f231e170e52e71e3510b99c373b6e571b55d9c7b31b679c0fed47c"
+            ],
+            "markers": "python_full_version >= '3.10.0'",
+            "version": "==8.0.0"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325",
+                "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.7.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4",
+                "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==26.0"
+        },
+        "platformdirs": {
+            "hashes": [
+                "sha256:9170634f126f8efdae22fb58ae8a0eaa86f38365bc57897a6c4f781d1f5875bd",
+                "sha256:9a33809944b9db043ad67ca0db94b14bf452cc6aeaac46a88ea55b26e2e9d291"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==4.9.2"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3",
+                "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==1.6.0"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783",
+                "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==2.14.0"
+        },
+        "pygments": {
+            "hashes": [
+                "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887",
+                "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.19.2"
+        },
+        "pylint": {
+            "hashes": [
+                "sha256:00f51c9b14a3b3ae08cff6b2cdd43f28165c78b165b628692e428fb1f8dc2cf2",
+                "sha256:8cd6a618df75deb013bd7eb98327a95f02a6fb839205a6bbf5456ef96afb317c"
+            ],
+            "index": "pypi",
+            "markers": "python_full_version >= '3.10.0'",
+            "version": "==4.0.5"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b",
+                "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==9.0.2"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6",
+                "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==2.32.5"
+        },
+        "tomli": {
+            "hashes": [
+                "sha256:0408e3de5ec77cc7f81960c362543cbbd91ef883e3138e81b729fc3eea5b9729",
+                "sha256:0dc56fef0e2c1c470aeac5b6ca8cc7b640bb93e92d9803ddaf9ea03e198f5b0b",
+                "sha256:0e0fe8a0b8312acf3a88077a0802565cb09ee34107813bba1c7cd591fa6cfc8d",
+                "sha256:0f2e3955efea4d1cfbcb87bc321e00dc08d2bcb737fd1d5e398af111d86db5df",
+                "sha256:133e93646ec4300d651839d382d63edff11d8978be23da4cc106f5a18b7d0576",
+                "sha256:1b168f2731796b045128c45982d3a4874057626da0e2ef1fdd722848b741361d",
+                "sha256:1c8a885b370751837c029ef9bc014f27d80840e48bac415f3412e6593bbc18c1",
+                "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a",
+                "sha256:1fb2945cbe303b1419e2706e711b7113da57b7db31ee378d08712d678a34e51e",
+                "sha256:20cedb4ee43278bc4f2fee6cb50daec836959aadaf948db5172e776dd3d993fc",
+                "sha256:20ffd184fb1df76a66e34bd1b36b4a4641bd2b82954befa32fe8163e79f1a702",
+                "sha256:26ab906a1eb794cd4e103691daa23d95c6919cc2fa9160000ac02370cc9dd3f6",
+                "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd",
+                "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4",
+                "sha256:31d556d079d72db7c584c0627ff3a24c5d3fb4f730221d3444f3efb1b2514776",
+                "sha256:36b9d05b51e65b254ea6c2585b59d2c4cb91c8a3d91d0ed0f17591a29aaea54a",
+                "sha256:39b0b5d1b6dd03684b3fb276407ebed7090bbec989fa55838c98560c01113b66",
+                "sha256:3cf226acb51d8f1c394c1b310e0e0e61fecdd7adcb78d01e294ac297dd2e7f87",
+                "sha256:3d895d56bd3f82ddd6faaff993c275efc2ff38e52322ea264122d72729dca2b2",
+                "sha256:413540dce94673591859c4c6f794dfeaa845e98bf35d72ed59636f869ef9f86f",
+                "sha256:43e685b9b2341681907759cf3a04e14d7104b3580f808cfde1dfdb60ada85475",
+                "sha256:4cbcb367d44a1f0c2be408758b43e1ffb5308abe0ea222897d6bfc8e8281ef2f",
+                "sha256:551e321c6ba03b55676970b47cb1b73f14a0a4dce6a3e1a9458fd6d921d72e95",
+                "sha256:5572e41282d5268eb09a697c89a7bee84fae66511f87533a6f88bd2f7b652da9",
+                "sha256:5aa48d7c2356055feef06a43611fc401a07337d5b006be13a30f6c58f869e3c3",
+                "sha256:5b5807f3999fb66776dbce568cc9a828544244a8eb84b84b9bafc080c99597b9",
+                "sha256:5e3f639a7a8f10069d0e15408c0b96a2a828cfdec6fca05296ebcdcc28ca7c76",
+                "sha256:685306e2cc7da35be4ee914fd34ab801a6acacb061b6a7abca922aaf9ad368da",
+                "sha256:75c2f8bbddf170e8effc98f5e9084a8751f8174ea6ccf4fca5398436e0320bc8",
+                "sha256:7b438885858efd5be02a9a133caf5812b8776ee0c969fea02c45e8e3f296ba51",
+                "sha256:7d49c66a7d5e56ac959cb6fc583aff0651094ec071ba9ad43df785abc2320d86",
+                "sha256:7d6d9a4aee98fac3eab4952ad1d73aee87359452d1c086b5ceb43ed02ddb16b8",
+                "sha256:84d081fbc252d1b6a982e1870660e7330fb8f90f676f6e78b052ad4e64714bf0",
+                "sha256:8768715ffc41f0008abe25d808c20c3d990f42b6e2e58305d5da280ae7d1fa3b",
+                "sha256:920b1de295e72887bafa3ad9f7a792f811847d57ea6b1215154030cf131f16b1",
+                "sha256:9a08144fa4cba33db5255f9b74f0b89888622109bd2776148f2597447f92a94e",
+                "sha256:a26d7ff68dfdb9f87a016ecfd1e1c2bacbe3108f4e0f8bcd2228ef9a766c787d",
+                "sha256:aa89c3f6c277dd275d8e243ad24f3b5e701491a860d5121f2cdd399fbb31fc9c",
+                "sha256:b5ef256a3fd497d4973c11bf142e9ed78b150d36f5773f1ca6088c230ffc5867",
+                "sha256:b6c78bdf37764092d369722d9946cb65b8767bfa4110f902a1b2542d8d173c8a",
+                "sha256:bbb1b10aa643d973366dc2cb1ad94f99c1726a02343d43cbc011edbfac579e7c",
+                "sha256:c084ad935abe686bd9c898e62a02a19abfc9760b5a79bc29644463eaf2840cb0",
+                "sha256:c73add4bb52a206fd0c0723432db123c0c75c280cbd67174dd9d2db228ebb1b4",
+                "sha256:cae9c19ed12d4e8f3ebf46d1a75090e4c0dc16271c5bce1c833ac168f08fb614",
+                "sha256:d20b797a5c1ad80c516e41bc1fb0443ddb5006e9aaa7bda2d71978346aeb9132",
+                "sha256:d3d1654e11d724760cdb37a3d7691f0be9db5fbdaef59c9f532aabf87006dbaa",
+                "sha256:d878f2a6707cc9d53a1be1414bbb419e629c3d6e67f69230217bb663e76b5087"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.4.0"
+        },
+        "tomlkit": {
+            "hashes": [
+                "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680",
+                "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==0.14.0"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466",
+                "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==4.15.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
+                "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==2.6.3"
+        }
+    }
+}

--- a/build.sh
+++ b/build.sh
@@ -1,14 +1,15 @@
-# Create New Zip File
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install dependencies via Pipfile
+pipenv install
+
+SITE_PACKAGES="$(pipenv run python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')"
+
+# Create zip with Lambda handler and NFCU module
 zip -9 nfcu_alexa_skill.zip lambda_function.py
+zip -ur -9 nfcu_alexa_skill.zip nfcu/ -i "*.py"
+zip -ur -9 nfcu_alexa_skill.zip nfcu/ -i "*.json"
 
-# Install Requirements
-source venv/bin/activate 
-pip install -r requirements.txt
-
-# Add NFCU Module
-zip -ur -9 nfcu_alexa_skill.zip nfcu/ -i \*.py
-zip -ur -9 nfcu_alexa_skill.zip nfcu/ -i \*.json
-
-# Add Dependencies to Zip
-cd venv/lib/python2.7/site-packages
-zip -ur -9 ~/Projects/Personal/Alexa/nfcu/nfcu_alexa_skill.zip * -i \*.py \*.pem
+# Bundle dependencies
+(cd "$SITE_PACKAGES" && zip -ur -9 "$OLDPWD/nfcu_alexa_skill.zip" . -i "*.py" "*.pem")

--- a/example.py
+++ b/example.py
@@ -1,22 +1,23 @@
 """
 Entrypoint for NFCU
 """
-from json.decoder import JSONDecodeError
 import json
+import sys
+
 import nfcu
 
 if __name__ == "__main__":
-
     try:
-        with open('.config/creds') as df:
-            creds = json.load(df)
-        access_number = creds.get('access_number')
-        password = creds.get('password')
-    except JSONDecodeError as e:
-        access_number, password = None, None
+        with open(".config/creds", encoding="utf-8") as creds_file:
+            creds = json.load(creds_file)
+    except (OSError, json.JSONDecodeError) as exc:
+        sys.exit(f"Could not load .config/creds: {exc}")
 
-    if access_number and password:
-        bank = nfcu.NFCU(access_number, password)
-        print(json.dumps(bank.get_account_summary()))
-    else:
-        print("Please configure .config/creds, see .config/creds-sample")
+    username = creds.get("username")
+    password = creds.get("password")
+
+    if not username or not password:
+        sys.exit("Please configure .config/creds — see .config/creds-sample")
+
+    bank = nfcu.NFCU(username, password)
+    print(json.dumps(bank.get_account_summary(), indent=2))

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -1,209 +1,138 @@
 """
-Alexa Skill for Getting
-Navy Federal Credit Union
-Account Data
+Alexa Skill for Getting Navy Federal Credit Union Account Data
 """
-from __future__ import print_function
+import os
+
 import nfcu
 
 
-def build_speechlet_response(title, output, reprompt_text, should_end_session):
-    """
-    Build alexa speechlet response
-    """
+def _build_speechlet_response(title, output, reprompt_text, should_end_session):
     return {
-        'outputSpeech': {
-            'type': 'PlainText',
-            'text': output
+        "outputSpeech": {"type": "PlainText", "text": output},
+        "card": {
+            "type": "Simple",
+            "title": f"SessionSpeechlet - {title}",
+            "content": f"SessionSpeechlet - {output}",
         },
-        'card': {
-            'type': 'Simple',
-            'title': "SessionSpeechlet - " + title,
-            'content': "SessionSpeechlet - " + output
-        },
-        'reprompt': {
-            'outputSpeech': {
-                'type': 'PlainText',
-                'text': reprompt_text
-            }
-        },
-        'shouldEndSession': should_end_session
+        "reprompt": {"outputSpeech": {"type": "PlainText", "text": reprompt_text}},
+        "shouldEndSession": should_end_session,
     }
 
 
-def build_response(session_attributes, speechlet_response):
-    """
-    Build response for Alexa
-    """
+def _build_response(session_attributes, speechlet_response):
     return {
-        'version': '1.0',
-        'sessionAttributes': session_attributes,
-        'response': speechlet_response
+        "version": "1.0",
+        "sessionAttributes": session_attributes,
+        "response": speechlet_response,
     }
 
 
-def get_welcome_response():
-    """
-    Set welcome message from alexa
-    """
-    session_attributes = {}
-    card_title = "Welcome"
-    speech_output = "Do you want to check your balance?"
-
-    # If the user either does not reply to the
-    # welcome message or says something
-    # that is not understood, they will be prompted
-    # again with this text.
-    reprompt_text = "Do you want to check your balance?"
-
-    should_end_session = True
-    return build_response(session_attributes, build_speechlet_response(
-        card_title, speech_output, reprompt_text, should_end_session))
+def _get_welcome_response():
+    return _build_response(
+        {},
+        _build_speechlet_response(
+            "Welcome",
+            "Do you want to check your balance?",
+            "Do you want to check your balance?",
+            True,
+        ),
+    )
 
 
-def get_account_summary():
-    """
-    Get all balances
-    """
-    session_attributes = {}
-    card_title = "AccountSummary"
+def _get_account_summary():
+    username = os.environ["NFCU_USERNAME"]
+    password = os.environ["NFCU_PASSWORD"]
 
-    # Calculate Total in All Accounts
-    access_number, password = 1, 2
-
-    api = nfcu.NFCU(access_number, password)
+    api = nfcu.NFCU(username, password)
     data = api.get_account_summary()
 
-    total = 0
-    for item in data["accountSummary"]["data"]["accountCategories"]:
-        total += item["totalBalance"]
+    total = sum(
+        item["totalBalance"]
+        for item in data["accountSummary"]["data"]["accountCategories"]
+    )
 
-    speech_output = "Your total account balance is ${total}".format(
-        total=total)
-
-    reprompt_text = speech_output
-    should_end_session = True
-
-    return build_response(session_attributes, build_speechlet_response(
-        card_title, speech_output, reprompt_text, should_end_session))
+    speech_output = f"Your total account balance is ${total:.2f}"
+    return _build_response(
+        {},
+        _build_speechlet_response("AccountSummary", speech_output, speech_output, True),
+    )
 
 
-def get_specific_account_balance():
-    """
-    Get specific account balance
-    """
-    session_attributes = {}
-    card_title = "AccountDetailedSummary"
-
-    # Calculate Total in All Accounts
-    access_number, password = 1, 2
-
-    api = nfcu.NFCU(access_number, password)
-    data = api.get_account_summary()
-    total = 0
-    for item in data["accountSummary"]["data"]["accountCategories"]:
-        total += item["totalBalance"]
-
-    speech_output = "Your total account balance is ${total}".format(
-        total=total)
-
-    reprompt_text = speech_output
-    should_end_session = True
-
-    return build_response(session_attributes, build_speechlet_response(
-        card_title, speech_output, reprompt_text, should_end_session))
+def _handle_session_end():
+    return _build_response(
+        {},
+        _build_speechlet_response("Session Ended", "Bye now.", None, True),
+    )
 
 
-def handle_session_end_request():
-    """
-    Set alexa response on close app
-    """
-    card_title = "Session Ended"
-    speech_output = "Bye now."
-
-    # Setting this to true ends the session and exits the skill.
-    should_end_session = True
-    return build_response({}, build_speechlet_response(
-        card_title, speech_output, None, should_end_session))
-
-
-# --------------- Events ------------------
 def on_session_started(session_started_request, session):
-    """
-    Called when the session starts
-    """
-
-    print("on_session_started requestId=" +
-          session_started_request['requestId'] +
-          ", sessionId=" + session['sessionId'])
+    """Called when the session starts."""
+    print(
+        f"on_session_started requestId={session_started_request['requestId']}, "
+        f"sessionId={session['sessionId']}"
+    )
 
 
 def on_launch(launch_request, session):
-    """
-    Called when the user launches the skill
-    without specifying what they want
-    """
-
-    print("on_launch requestId=" + launch_request['requestId'] +
-          ", sessionId=" + session['sessionId'])
-    # Dispatch to your skill's launch
-    return get_welcome_response()
+    """Called when the user launches the skill without specifying what they want."""
+    print(
+        f"on_launch requestId={launch_request['requestId']}, "
+        f"sessionId={session['sessionId']}"
+    )
+    return _get_welcome_response()
 
 
 def on_intent(intent_request, session):
-    """
-    Called when the user specifies an intent for this skill
-    """
+    """Called when the user specifies an intent for this skill."""
+    print(
+        f"on_intent requestId={intent_request['requestId']}, "
+        f"sessionId={session['sessionId']}"
+    )
 
-    print("on_intent requestId=" + intent_request['requestId'] +
-          ", sessionId=" + session['sessionId'])
+    intent_name = intent_request["intent"]["name"]
 
-    intent_name = intent_request['intent']['name']
+    handlers = {
+        "GetAccountSummary": _get_account_summary,
+        "AMAZON.HelpIntent": _get_welcome_response,
+        "AMAZON.CancelIntent": _handle_session_end,
+        "AMAZON.StopIntent": _handle_session_end,
+    }
 
-    # Dispatch to your skill's intent handlers
-    if intent_name == "GetAccountSummary":
-        return get_account_summary()
-    elif intent_name == "AMAZON.HelpIntent":
-        return get_welcome_response()
-    elif intent_name == "AMAZON.CancelIntent" or \
-            intent_name == "AMAZON.StopIntent":
-        return handle_session_end_request()
-    else:
-        raise ValueError("Invalid intent")
+    handler = handlers.get(intent_name)
+    if handler is None:
+        raise ValueError(f"Unrecognised intent: {intent_name}")
+    return handler()
 
 
 def on_session_ended(session_ended_request, session):
-    """
-    Called when the user ends the session.
-    Is not called when the skill
-    :return: should_end_session=true
-    """
-    print("on_session_ended requestId=" + session_ended_request['requestId'] +
-          ", sessionId=" + session['sessionId'])
-    # add cleanup logic here
+    """Called when the user ends the session."""
+    print(
+        f"on_session_ended requestId={session_ended_request['requestId']}, "
+        f"sessionId={session['sessionId']}"
+    )
 
 
-# --------------- Main handler ------------------
-def lambda_handler(event):
+def lambda_handler(event, context):  # noqa: ARG001
     """
     Route the incoming request based on type
-    (LaunchRequest, IntentRequest, etc.)
+    (LaunchRequest, IntentRequest, etc.).
     The JSON body of the request is provided in the event parameter.
     """
-    print("event.session.application.applicationId=" +
-          event['session']['application']['applicationId'])
+    print(
+        f"event.session.application.applicationId="
+        f"{event['session']['application']['applicationId']}"
+    )
 
-    if event['session']['new']:
+    if event["session"]["new"]:
         on_session_started(
-            {
-                'requestId': event['request']['requestId']
-            },
-            event['session']
+            {"requestId": event["request"]["requestId"]},
+            event["session"],
         )
 
-    if event['request']['type'] == "LaunchRequest":
-        return on_launch(event['request'], event['session'])
-    elif event['request']['type'] == "IntentRequest":
-        return on_intent(event['request'], event['session'])
-    elif event['request']['type'] == "SessionEndedRequest":
-        return on_session_ended(event['request'], event['session'])
+    request_type = event["request"]["type"]
+    if request_type == "LaunchRequest":
+        return on_launch(event["request"], event["session"])
+    if request_type == "IntentRequest":
+        return on_intent(event["request"], event["session"])
+    if request_type == "SessionEndedRequest":
+        return on_session_ended(event["request"], event["session"])

--- a/nfcu/__init__.py
+++ b/nfcu/__init__.py
@@ -2,141 +2,107 @@
 Navy Federal Module
 Fork of https://github.com/tjhorner/node-nfcu
 """
+from __future__ import annotations
+
 import json
-import os
+from pathlib import Path
+
 import requests
 
-from nfcu.constants import RISK_JSON
-from nfcu.exceptions import *
+from nfcu.exceptions import (
+    NFCUGetError,
+    NFCULoginError,
+    NFCUMFAError,
+    NFCUPostError,
+    NFCUSummaryError,
+)
+
+_API_BASE = "https://mservices.navyfcu.org/"
+
+_HEADERS = {
+    "Accept": "application/json; charset=UTF-8",
+    # Imitate a Nexus 6P running Android 6.0.1
+    "User-Agent": (
+        "Dalvik/2.1.0 (Linux; U; Android 6.0.1; Nexus 6P Build/MMB29M)"
+    ),
+    "Content-Type": "application/json",
+    "Host": "mservices.navyfcu.org",
+}
+
+_RISK_JSON_PATH = Path(__file__).parent / "data" / "riskcheck.json"
+_REQUEST_TIMEOUT = 30
 
 
 class NFCU:
-    '''Navy Federal Class'''
+    """Navy Federal Credit Union API client."""
 
-    API_BASE = 'https://mservices.navyfcu.org/'
-    DATE_FORMAT = 'YYYY-MM-DD'
-
-    def __init__(self, access_number, password):
-        '''Make NFCU object'''
-        self.access_number = access_number
+    def __init__(self, username: str, password: str) -> None:
+        self.username = username
         self.password = password
-        self._cookie = None
+        self._cookie: requests.cookies.RequestsCookieJar | None = None
         self.login()
 
-    @staticmethod
-    def _get_headers():
-        '''Get Headers for call'''
-        headers = {
-            'Accept': 'application/json; charset=UTF-8',
-            # Imitate a Nexus 6P
-            'User-Agent': 'Dalvik/2.1.0 (Linux; U; Android 6.0.1; Nexus 6P Build/MMB29M)',
-            'Content-Type': 'application/json',
-            'Host': 'mservices.navyfcu.org'
-        }
-        return headers
-
-    def _get(self, endpoint):
-        '''Wrapper for GETting requests with
-        authentication
-
-        :param endpoint: API URI
-        '''
-        cookie = self._cookie
-
+    def _get(self, endpoint: str) -> dict:
         response = requests.get(
-            self.API_BASE + endpoint,
-            headers=self._get_headers(),
-            cookies=cookie
+            _API_BASE + endpoint,
+            headers=_HEADERS,
+            cookies=self._cookie,
+            timeout=_REQUEST_TIMEOUT,
         )
         if response.status_code == 200:
             return response.json()
         raise NFCUGetError(
-            f'Received error from NGCU API: {response.content}, {response.status_code}'
+            f"GET {endpoint} returned {response.status_code}: "
+            f"{response.content}"
         )
 
-    def _post(self, endpoint, post_data):
-        '''Wrapper for POSTing requests with
-        authentication
-
-        :param endpoint: API URI
-        :param post_data: Post Data
-        '''
-        cookie = self._cookie
+    def _post(self, endpoint: str, post_data: dict) -> requests.Response:
         response = requests.post(
-            self.API_BASE + endpoint,
-            headers=self._get_headers(),
+            _API_BASE + endpoint,
+            headers=_HEADERS,
             data=json.dumps(post_data),
-            cookies=cookie
+            cookies=self._cookie,
+            timeout=_REQUEST_TIMEOUT,
         )
         if response.status_code == 200:
             return response
         raise NFCUPostError(
-            f'Received error from NFCU API: {response.content}, {response.status_code}'
+            f"POST {endpoint} returned {response.status_code}: "
+            f"{response.content}"
         )
 
-    def login(self):
-        '''Login to NFCU
-
-        :param access_number: NFCU Access Number
-        :param password: NFCU password
-        :param callback: Callback func
-        '''
+    def login(self) -> None:
+        """Authenticate with NFCU."""
         response = self._post(
-            'Authenticator/services/loginv3',
+            "Authenticator/services/loginv3",
             {
-                'appVersion': '6.0.1',
-                'deviceModel': 'Nexus 6p',
-                'osPlatform': 'AND',
-                'osVersion': '6.0.1',
-                'username': self.access_number,
-                'password': self.password
-            }
+                "appVersion": "6.0.1",
+                "deviceModel": "Nexus 6p",
+                "osPlatform": "AND",
+                "osVersion": "6.0.1",
+                "username": self.username,
+                "password": self.password,
+            },
         )
         message = response.json()
-        if message['loginv2']['status'] == 'SUCCESS':
+        if message["loginv3"]["status"] == "SUCCESS":
             self._cookie = response.cookies
             self.submit_mfa()
             return
-        raise NFCULoginError(
-            f'Login error: {message}'
-        )
+        raise NFCULoginError(f"Login failed: {message}")
 
-    def submit_mfa(self):
-        '''MFA to auth request'''
-        try:
-            data_file = os.path.abspath(
-                os.path.join(
-                    os.path.dirname(__file__),
-                    'data/riskcheck.json'
-                )
-            )
-            with open(data_file, encoding='utf8') as file_handle:
-                payload = json.load(file_handle)
-        except json.JSONDecodeError as error:
-            print(error.msg)
-            payload = json.dumps(RISK_JSON)
-
-        response = self._post(
-            'MFA/services/riskCheck',
-            payload
-        )
+    def submit_mfa(self) -> None:
+        """Submit device fingerprint to satisfy MFA."""
+        payload = json.loads(_RISK_JSON_PATH.read_text(encoding="utf-8"))
+        response = self._post("MFA/services/riskCheck", payload)
         message = response.json()
-
-        if message['riskCheck']['status'] == 'SUCCESS':
+        if message["riskCheck"]["status"] == "SUCCESS":
             return
-        raise NFCUMFAError(
-            f'Unable to proceed: {message}'
-        )
+        raise NFCUMFAError(f"MFA failed: {message}")
 
-    def get_account_summary(self):
-        '''Get summary of all of the logged-in
-        user's accounts
-
-        :param callback: Callback func
-        '''
-        response = self._get('NativeBanking/services/accountSummary')
-        if response['accountSummary']['status'] == 'SUCCESS':
+    def get_account_summary(self) -> dict:
+        """Return summary data for all accounts."""
+        response = self._get("NativeBanking/services/accountSummary")
+        if response["accountSummary"]["status"] == "SUCCESS":
             return response
-        raise NFCUSummaryError(
-            f'Unable to get account summary: {response}'
-        )
+        raise NFCUSummaryError(f"Account summary failed: {response}")

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,0 @@
-coverage==5.0.1
-coveralls==1.10.0
-pytest==5.3.2
-pylint==2.13.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-requests==2.22.0
-simplejson==3.17.0

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
-from distutils.core import setup
-from setuptools import find_packages
+from setuptools import find_packages, setup
 
 setup(
     name='nfcu',
@@ -11,5 +10,7 @@ setup(
     url='https://github.com/morissette/nfcu',
     download_url='https://github.com/morissette/nfcu/tarball/0.1.2',
     keywords=['nfcu', 'fintech', 'navy federal', 'api'],
+    python_requires='>=3.10',
+    install_requires=['requests>=2.32.0'],
     classifiers=[],
 )

--- a/test/test_nfcu.py
+++ b/test/test_nfcu.py
@@ -1,9 +1,214 @@
 """
-Place Holder Tests
+Unit tests for the nfcu package.
+All network calls are mocked — no live API required.
 """
-import nfcu
-import pytest
+import json
+from unittest.mock import MagicMock, patch
 
-class TestNFCU:
-    def test_placeholder_one(self):
-        assert True == True
+import pytest
+import requests
+
+import nfcu
+from nfcu.exceptions import (
+    NFCUGetError,
+    NFCULoginError,
+    NFCUMFAError,
+    NFCUPostError,
+    NFCUSummaryError,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+USERNAME = "test_user"
+PASSWORD = "test_pass"
+
+LOGIN_SUCCESS = {"loginv3": {"status": "SUCCESS"}}
+LOGIN_FAILED = {
+    "loginv3": {
+        "status": "FAILED",
+        "errors": [{"errorCode": "000E", "errorMsg": "Bad credentials"}],
+    }
+}
+MFA_SUCCESS = {"riskCheck": {"status": "SUCCESS"}}
+MFA_FAILED = {"riskCheck": {"status": "FAILED"}}
+ACCOUNT_SUMMARY_SUCCESS = {
+    "accountSummary": {
+        "status": "SUCCESS",
+        "data": {
+            "accountCategories": [
+                {"totalBalance": 1000.00},
+                {"totalBalance": 500.00},
+            ]
+        },
+    }
+}
+ACCOUNT_SUMMARY_FAILED = {"accountSummary": {"status": "FAILED"}}
+
+
+def _mock_response(status_code=200, json_body=None):
+    """Build a mock requests.Response."""
+    mock = MagicMock(spec=requests.Response)
+    mock.status_code = status_code
+    mock.json.return_value = json_body or {}
+    mock.cookies = MagicMock()
+    mock.content = json.dumps(json_body or {}).encode()
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# NFCU initialisation
+# ---------------------------------------------------------------------------
+
+class TestNFCUInit:
+    def test_login_called_on_init(self):
+        with patch.object(nfcu.NFCU, "login") as mock_login:
+            client = nfcu.NFCU(USERNAME, PASSWORD)
+        mock_login.assert_called_once()
+        assert client.username == USERNAME
+        assert client.password == PASSWORD
+        assert client._cookie is None  # noqa: SLF001 – testing internal state
+
+    def test_credentials_stored(self):
+        with patch.object(nfcu.NFCU, "login"):
+            client = nfcu.NFCU(USERNAME, PASSWORD)
+        assert client.username == USERNAME
+        assert client.password == PASSWORD
+
+
+# ---------------------------------------------------------------------------
+# login()
+# ---------------------------------------------------------------------------
+
+class TestLogin:
+    def _make_client(self):
+        """Return an NFCU client with login suppressed."""
+        with patch.object(nfcu.NFCU, "login"):
+            return nfcu.NFCU(USERNAME, PASSWORD)
+
+    def test_login_success_stores_cookie_and_calls_mfa(self):
+        client = self._make_client()
+        mock_resp = _mock_response(200, LOGIN_SUCCESS)
+
+        with patch.object(client, "_post", return_value=mock_resp), \
+                patch.object(client, "submit_mfa") as mock_mfa:
+            client.login()
+
+        assert client._cookie is mock_resp.cookies  # noqa: SLF001
+        mock_mfa.assert_called_once()
+
+    def test_login_failed_status_raises(self):
+        client = self._make_client()
+        mock_resp = _mock_response(200, LOGIN_FAILED)
+
+        with patch.object(client, "_post", return_value=mock_resp):
+            with pytest.raises(NFCULoginError):
+                client.login()
+
+    def test_login_post_error_propagates(self):
+        client = self._make_client()
+
+        with patch.object(client, "_post", side_effect=NFCUPostError("boom")):
+            with pytest.raises(NFCUPostError):
+                client.login()
+
+
+# ---------------------------------------------------------------------------
+# submit_mfa()
+# ---------------------------------------------------------------------------
+
+class TestSubmitMFA:
+    def _make_client(self):
+        with patch.object(nfcu.NFCU, "login"):
+            return nfcu.NFCU(USERNAME, PASSWORD)
+
+    def test_mfa_success(self):
+        client = self._make_client()
+        mock_resp = _mock_response(200, MFA_SUCCESS)
+
+        with patch.object(client, "_post", return_value=mock_resp):
+            client.submit_mfa()  # should not raise
+
+    def test_mfa_failed_status_raises(self):
+        client = self._make_client()
+        mock_resp = _mock_response(200, MFA_FAILED)
+
+        with patch.object(client, "_post", return_value=mock_resp):
+            with pytest.raises(NFCUMFAError):
+                client.submit_mfa()
+
+    def test_mfa_missing_json_file_raises(self, tmp_path, monkeypatch):
+        import nfcu as nfcu_module
+        monkeypatch.setattr(nfcu_module, "_RISK_JSON_PATH", tmp_path / "missing.json")
+        client = self._make_client()
+
+        with pytest.raises(FileNotFoundError):
+            client.submit_mfa()
+
+
+# ---------------------------------------------------------------------------
+# get_account_summary()
+# ---------------------------------------------------------------------------
+
+class TestGetAccountSummary:
+    def _make_client(self):
+        with patch.object(nfcu.NFCU, "login"):
+            return nfcu.NFCU(USERNAME, PASSWORD)
+
+    def test_success_returns_response(self):
+        client = self._make_client()
+
+        with patch.object(client, "_get", return_value=ACCOUNT_SUMMARY_SUCCESS):
+            result = client.get_account_summary()
+
+        assert result == ACCOUNT_SUMMARY_SUCCESS
+
+    def test_failed_status_raises(self):
+        client = self._make_client()
+
+        with patch.object(client, "_get", return_value=ACCOUNT_SUMMARY_FAILED):
+            with pytest.raises(NFCUSummaryError):
+                client.get_account_summary()
+
+
+# ---------------------------------------------------------------------------
+# _get() / _post() HTTP error handling
+# ---------------------------------------------------------------------------
+
+class TestHTTPWrappers:
+    def _make_client(self):
+        with patch.object(nfcu.NFCU, "login"):
+            return nfcu.NFCU(USERNAME, PASSWORD)
+
+    def test_get_non_200_raises_nfcu_get_error(self):
+        client = self._make_client()
+
+        with patch("nfcu.requests.get", return_value=_mock_response(401)):
+            with pytest.raises(NFCUGetError):
+                client._get("some/endpoint")  # noqa: SLF001
+
+    def test_post_non_200_raises_nfcu_post_error(self):
+        client = self._make_client()
+
+        with patch("nfcu.requests.post", return_value=_mock_response(403)):
+            with pytest.raises(NFCUPostError):
+                client._post("some/endpoint", {})  # noqa: SLF001
+
+    def test_get_200_returns_json(self):
+        client = self._make_client()
+        payload = {"key": "value"}
+
+        with patch("nfcu.requests.get", return_value=_mock_response(200, payload)):
+            result = client._get("some/endpoint")  # noqa: SLF001
+
+        assert result == payload
+
+    def test_post_200_returns_response(self):
+        client = self._make_client()
+        mock_resp = _mock_response(200, {"ok": True})
+
+        with patch("nfcu.requests.post", return_value=mock_resp):
+            result = client._post("some/endpoint", {})  # noqa: SLF001
+
+        assert result is mock_resp


### PR DESCRIPTION
## Summary

- **Migrate to Pipfile** — replace `requirements.txt` / `requirements-test.txt` with `Pipfile` + `Pipfile.lock`; drop unused `simplejson`; pin `requests>=2.32.0` (fixes Python 3.14 incompatibility)
- **Fix critical bugs** — correct `loginv2` → `loginv3` response key (would `KeyError` on successful auth); fix `lambda_handler` missing `context` param; remove silent MFA fallback that double-encoded JSON
- **Modernise `nfcu/__init__.py`** — rename `access_number` → `username` to match migrated API; explicit exception imports (no more `import *`); `pathlib` over `os.path`; module-level `_HEADERS` constant; type hints; request timeouts; remove dead `DATE_FORMAT`
- **Fix `lambda_function.py`** — remove Python 2 `__future__` import; credentials from `NFCU_USERNAME` / `NFCU_PASSWORD` env vars (remove hardcoded `1, 2`); f-strings; remove duplicate `get_specific_account_balance`; dict-based intent dispatch
- **Fix `example.py`** — load `username` from creds file; `sys.exit` on error instead of silent fallback
- **Fix `setup.py`** — `distutils` (removed in Python 3.12) → `setuptools`; add `python_requires=">=3.10"` and `install_requires`
- **Update CI** — `.travis.yml` targets EOL-replaced 3.10–3.13; all commands via `pipenv run`; fix `build.sh` Python 2.7 site-packages path
- **Real test suite** — replace single placeholder with 14 mocked unit tests covering login, MFA, account summary, and HTTP error paths

## Test plan

- [ ] `pipenv install --dev && pipenv run pip install -e .`
- [ ] `pipenv run pytest test/ -v` — 14 tests, all pass
- [ ] `pipenv run pylint nfcu/` — 10.00/10
- [ ] `pipenv run pycodestyle nfcu/` — no violations
- [ ] Confirm Dependabot security alerts on `master` are resolved after merge (stale `requests==2.22.0` / `simplejson==3.17.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)