### PR TITLE
Replace Travis/Coveralls badges with GitHub Actions status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://travis-ci.org/morissette/nfcu.svg?branch=master)](https://travis-ci.org/morissette/nfcu)
-[![Coverage Status](https://coveralls.io/repos/github/morissette/nfcu/badge.svg?branch=master)](https://coveralls.io/github/morissette/nfcu?branch=master)
+[![CI](https://github.com/morissette/nfcu/actions/workflows/ci.yml/badge.svg)](https://github.com/morissette/nfcu/actions/workflows/ci.yml)
+[![Release](https://github.com/morissette/nfcu/actions/workflows/release.yml/badge.svg)](https://github.com/morissette/nfcu/actions/workflows/release.yml)
 
 # Navy Federal
 


### PR DESCRIPTION
## Summary
- Replaces defunct Travis CI build badge with GitHub Actions CI badge
- Replaces Coveralls coverage badge with GitHub Actions Release badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)